### PR TITLE
fix .mrpack generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ function generateMRPack() {
     const packData = {
         formatVersion: 1,
         game: 'minecraft',
-        version: `${typeOptions.version}-${typeOptions.os}-${typeOptions.run}-custom`,
+        versionId: `${typeOptions.version}-${typeOptions.os}-${typeOptions.run}-custom`,
         name: `MCSR Custom Pack`,
         dependencies: {
             "fabric-loader": ALLOW_MODS.find(mod => mod.name == 'Fabric Loader').files[0].version,


### PR DESCRIPTION
Hey, I was trying to set up mods using this tool and the mrpack export, but it seemed that modrinth did not like the generated file.  Checking the [mrpack format docs](https://docs.modrinth.com/modpacks/format#versionid), it looks like they are expecting `versionId` instead of `version` in the json object.  Editing this in by hand seemed to fix it for me, so I think this way is correct.  Thanks for maintaining the list!